### PR TITLE
Correction

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -223,7 +223,7 @@ resources:
                 ProxyType: Internet
                 Type: HTTP
                 URL: https://${org}.launchpad.${default-domain} # Runtime destination of launchpad, required for workzone
-                CEP.HTML5contentprovider: true
+                CEP.HTML5ContentProvider: true
               - Name: poetry-slams-srv-api
                 Description: Destination to access the poetry slams service module, required for workzone
                 Authentication: NoAuthentication


### PR DESCRIPTION
Correction of spelling mistake in Work Zone runtime destination parameter: CEP.HTML5ContentProvider in mta.yaml