### PR TITLE
2508 Work Zone (tutorial)

### DIFF
--- a/Tutorials/23-Multi-Tenancy-Develop-Sample-Application.md
+++ b/Tutorials/23-Multi-Tenancy-Develop-Sample-Application.md
@@ -234,7 +234,7 @@ Now, follow the next steps to make further required changes:
                         ProxyType: Internet
                         Type: HTTP
                         URL: https://${org}.launchpad.${default-domain} # Runtime destination of launchpad, required for workzone
-                        CEP.HTML5contentprovider: true
+                        CEP.HTML5ContentProvider: true
                       - Name: poetry-slams-srv-api
                         Description: Destination to access the poetry slams service module, required for workzone
                         Authentication: NoAuthentication


### PR DESCRIPTION
Correction of spelling mistake in Work Zone runtime destination parameter: CEP.HTML5ContentProvider in mta.yaml